### PR TITLE
#update/article comment pagination

### DIFF
--- a/components/article/ArticleCommentItem.tsx
+++ b/components/article/ArticleCommentItem.tsx
@@ -7,20 +7,53 @@ import { MdMoreHoriz } from "react-icons/md";
 import { useAuthCtx } from "../../utils/contexts/auth/AuthHook";
 import { CommentModel } from "../../utils/data/models/CommentModel";
 import {
-  dateDistanceGet, userAvatarLinkGet
+  dateDistanceGet,
+  userAvatarLinkGet,
 } from "../../utils/helpers/MainHelpers";
+import { getElById } from "../../utils/helpers/UiHelpers";
 import { fbCommentReact } from "../../utils/services/network/FirebaseApi/FirebaseCommentModules";
+import MainIntersectionObserverTrigger from "../main/MainIntersectionObserverTrigger";
 import UserAvatar from "../user/UserAvatar";
-
-function ArticleCommentItem({
-  comment: commentProps,
-  optionParam,
-  replyParam,
-}: {
+import ArticleCommentItemActionButton from "./ArticleCommentItemActionButton";
+interface ArticleCommentItemProps {
   comment: CommentModel;
   optionParam: string;
   replyParam: string;
-}) {
+}
+
+function ArticleCommentItem({
+  observe,
+  ...props
+}: ArticleCommentItemProps & { observe?: boolean }) {
+  const [visible, setVisible] = useState(true);
+  const elementId = `comment-${{ ...props }.comment.id}`;
+  const element = getElById(elementId);
+  return observe ? (
+    <MainIntersectionObserverTrigger
+      id={elementId}
+      callback={(intersecting) => setVisible(intersecting)}
+      className=""
+      style={
+        visible
+          ? undefined
+          : {
+              height: `${element?.clientHeight}px`,
+              width: `100%`,
+            }
+      }
+    >
+      {visible && <ArticleCommentItemContent {...props} />}
+    </MainIntersectionObserverTrigger>
+  ) : (
+    <ArticleCommentItemContent {...props} />
+  );
+}
+
+function ArticleCommentItemContent({
+  comment: commentProps,
+  optionParam,
+  replyParam,
+}: ArticleCommentItemProps) {
   const router = useRouter();
   const {
     authStt: { user },
@@ -205,31 +238,5 @@ export interface CommentActionProps {
   minimize?: boolean;
   action?: () => void;
 }
-
-const ArticleCommentItemActionButton = ({
-  label,
-  icon,
-  className,
-  minimize = true,
-  action = () => {},
-}: CommentActionProps) => {
-  return (
-    <span
-      className={`btn btn-ghost rounded-xl p-1 sm:p-2 opacity-75 hover:opacity-100
-      !flex !flex-nowrap max-w-none gap-1 sm:gap-2 !h-auto aspect-square sm:aspect-auto
-      !font-black
-      group ${className || ""}`}
-      title="Upvote"
-      onClick={() => action()}
-    >
-      {icon && <span className="text-xl sm:text-2xl">{icon}</span>}
-      {label && (
-        <span className={minimize ? "hidden sm:block" : "!text-sm sm:!text-md"}>
-          {label}
-        </span>
-      )}
-    </span>
-  );
-};
 
 export default React.memo(ArticleCommentItem);

--- a/components/article/ArticleCommentItem.tsx
+++ b/components/article/ArticleCommentItem.tsx
@@ -26,7 +26,7 @@ function ArticleCommentItem({
     authStt: { user },
   } = useAuthCtx();
   const [comment, setComment] = useState(commentProps);
-  const postedAt = dateDistanceGet(comment.dateAdded, Date.now());
+  const postedAt = `${dateDistanceGet(comment.dateAdded, Date.now())} ago`;
   const userAvatar = userAvatarLinkGet(comment.userId);
   const upvoted = comment.upvote?.includes(user?.id || "");
   const downvoted = comment.downvote?.includes(user?.id || "");

--- a/components/article/ArticleCommentItem.tsx
+++ b/components/article/ArticleCommentItem.tsx
@@ -7,17 +7,19 @@ import { MdMoreHoriz } from "react-icons/md";
 import { useAuthCtx } from "../../utils/contexts/auth/AuthHook";
 import { CommentModel } from "../../utils/data/models/CommentModel";
 import {
-  dateDistanceGet,
-  routeTrimQuery,
-  userAvatarLinkGet,
+  dateDistanceGet, userAvatarLinkGet
 } from "../../utils/helpers/MainHelpers";
 import { fbCommentReact } from "../../utils/services/network/FirebaseApi/FirebaseCommentModules";
 import UserAvatar from "../user/UserAvatar";
 
 function ArticleCommentItem({
   comment: commentProps,
+  optionParam,
+  replyParam,
 }: {
   comment: CommentModel;
+  optionParam: string;
+  replyParam: string;
 }) {
   const router = useRouter();
   const {
@@ -74,9 +76,9 @@ function ArticleCommentItem({
         if (!isLoggedIn) return alert("You must login to do this action.");
         router.push(
           {
-            pathname: routeTrimQuery(router.asPath),
             query: {
-              reply: comment.id,
+              ...router.query,
+              [replyParam]: comment.id,
             },
           },
           undefined,
@@ -109,9 +111,10 @@ function ArticleCommentItem({
           {isLoggedIn && (
             <Link
               href={{
-                pathname: router.asPath,
+                // pathname: router.asPath,
                 query: {
-                  option: comment.id,
+                  ...router.query,
+                  [optionParam]: comment.id,
                 },
               }}
               shallow

--- a/components/article/ArticleCommentItem.tsx
+++ b/components/article/ArticleCommentItem.tsx
@@ -130,7 +130,7 @@ function ArticleCommentItemContent({
   return (
     <div className="flex flex-row items-start gap-2 sm:gap-4">
       <UserAvatar src={userAvatar} />
-      <div className="flex flex-1 flex-col gap-2">
+      <div className="flex flex-1 flex-col gap-2 overflow-hidden">
         <div className="inline-flex gap-4">
           <div className="flex flex-col">
             <span className="text-base font-bold !leading-[1.2] sm:text-lg capitalize">
@@ -220,7 +220,7 @@ function ArticleCommentItemContent({
           </>
           {/* </div> */}
         </div>
-        <span className="text-sm sm:text-base">{comment.content}</span>
+        <span className="text-sm sm:text-base truncate whitespace-pre-line">{`${comment.content}`}</span>
         <div className={`flex gap-2 sm:gap-4 items-center justify-end `}>
           {actions.map((e, idx) => {
             return <ArticleCommentItemActionButton key={idx} {...e} />;

--- a/components/article/ArticleCommentItemActionButton.tsx
+++ b/components/article/ArticleCommentItemActionButton.tsx
@@ -1,0 +1,28 @@
+import { CommentActionProps } from "./ArticleCommentItem";
+
+const ArticleCommentItemActionButton = ({
+  label,
+  icon,
+  className,
+  minimize = true,
+  action = () => {},
+}: CommentActionProps) => {
+  return (
+    <span
+      className={`btn btn-ghost rounded-xl p-1 sm:p-2 opacity-75 hover:opacity-100
+        !flex !flex-nowrap max-w-none gap-1 sm:gap-2 !h-auto aspect-square sm:aspect-auto
+        !font-black
+        group ${className || ""}`}
+      title="Upvote"
+      onClick={() => action()}
+    >
+      {icon && <span className="text-xl sm:text-2xl">{icon}</span>}
+      {label && (
+        <span className={minimize ? "hidden sm:block" : "!text-sm sm:!text-md"}>
+          {label}
+        </span>
+      )}
+    </span>
+  );
+};
+export default ArticleCommentItemActionButton;

--- a/components/article/ArticleComments.tsx
+++ b/components/article/ArticleComments.tsx
@@ -9,9 +9,11 @@ const optionParam = "option";
 const replyParam = "reply";
 function ArticleComments({
   commentList,
+  observe,
 }: // addComment,
 {
   commentList: CommentModelsWithPaging;
+  observe?: boolean;
   // addComment: (comments:Comment[]) => void;
 }) {
   const optionModal = useModalRoutedBehaviorHook(optionParam);
@@ -26,6 +28,7 @@ function ArticleComments({
             comment={e}
             optionParam={optionParam}
             replyParam={replyParam}
+            observe={observe}
           />
         ))}
       </div>

--- a/components/article/ArticleComments.tsx
+++ b/components/article/ArticleComments.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { CommentModelsWithPaging } from "../../utils/data/models/CommentModel";
-import { useArticleModalsBehaviorHook } from "../../utils/hooks/ArticleModalsBehaviorHook";
+import { useModalRoutedBehaviorHook } from "../../utils/hooks/ModalRoutedBehaviorHook";
 import ArticleCommentItem from "./ArticleCommentItem";
 import ArticleCommentOptionModal from "./ArticleCommentOptionModal";
 import ArticleCommentReplyModal from "./ArticleCommentReplyModal";
 
+const optionParam = "option";
+const replyParam = "reply";
 function ArticleComments({
   commentList,
 }: // addComment,
@@ -12,8 +14,8 @@ function ArticleComments({
   commentList: CommentModelsWithPaging;
   // addComment: (comments:Comment[]) => void;
 }) {
-  const { optionModal, closeOptionModal, replyModal, closeReplyModal } =
-    useArticleModalsBehaviorHook();
+  const optionModal = useModalRoutedBehaviorHook(optionParam);
+  const replyModal = useModalRoutedBehaviorHook(replyParam);
 
   return (
     <>
@@ -22,18 +24,18 @@ function ArticleComments({
           <ArticleCommentItem
             key={e.id}
             comment={e}
-            // openOptionModal={openOptionModal}
-            // openReplyModal={openReplyModal}
+            optionParam={optionParam}
+            replyParam={replyParam}
           />
         ))}
       </div>
       <ArticleCommentOptionModal
-        value={optionModal !== null}
-        onClose={closeOptionModal}
+        value={optionModal.show}
+        onClose={() => optionModal.toggle(false)}
       />
       <ArticleCommentReplyModal
-        value={replyModal !== null}
-        onClose={closeReplyModal}
+        value={replyModal.show}
+        onClose={() => replyModal.toggle(false)}
       />
     </>
   );

--- a/components/main/Dropdown.tsx
+++ b/components/main/Dropdown.tsx
@@ -1,0 +1,47 @@
+import React, { ReactNode } from "react";
+export interface DropdownOption {
+  icon?: ReactNode;
+  label: string;
+  action?: () => void;
+}
+
+function Dropdown({
+  options,
+  ...props
+}: { options: DropdownOption[] } & React.HTMLAttributes<HTMLDivElement>) {
+  const { className, children } = { ...props };
+  return (
+    <div {...props} className={`dropdown ${className}`}>
+      {children}
+      {!!options.length && (
+        <ul
+          tabIndex={0}
+          className="dropdown-content menu !z-[1] w-52 rounded-xl bg-base-300 p-2 text-sm
+          font-bold ring-[1px] ring-base-content/10 sm:text-base [&_a]:!rounded-xl"
+        >
+          {options.map((e, idx) => {
+            return (
+              <li key={idx}>
+                <a
+                  onClick={() => {
+                    e.action?.();
+                    (document.activeElement as HTMLElement).blur();
+                  }}
+                >
+                  {e.label}
+                </a>
+              </li>
+            );
+          })}
+          <li>
+            <a onClick={() => (document.activeElement as HTMLElement).blur()}>
+              Cancel
+            </a>
+          </li>
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default Dropdown;

--- a/components/main/MobileHeader.tsx
+++ b/components/main/MobileHeader.tsx
@@ -22,7 +22,7 @@ function MobileHeader({ title, back, actions, toTop }: MobileHeaderProps) {
       className="sm:hidden sticky inset-x-0 top-0 flex gap-2 justify-between items-center z-[10] bg-base-100/70 p-2 
        -mt-2 backdrop-blur-md animate-fadeInDown animate-duration-500"
     >
-      <div className="flex gap-2 items-center">
+      <div className="flex gap-1 items-center">
         {back && (
           <button
             className="btn rounded-xl btn-sm btn-ghost text-2xl text-primary aspect-square p-0 self-start"
@@ -34,8 +34,8 @@ function MobileHeader({ title, back, actions, toTop }: MobileHeaderProps) {
           </button>
         )}
         <span
-          className={`text-2xl font-bold ${toTop ? `cursor-pointer` : ``}`}
-          onClick={() => toTop?.() || scrollToTop(true)}
+          className={`text-xl font-bold ${toTop ? `cursor-pointer` : ``}`}
+          onClick={() => toTop ? toTop():scrollToTop(true)}
         >
           {title}
         </span>

--- a/components/main/MobileHeader.tsx
+++ b/components/main/MobileHeader.tsx
@@ -1,11 +1,13 @@
 import { ReactNode } from "react";
 import { MdArrowBack } from "react-icons/md";
 import { scrollToTop } from "../../utils/hooks/RouteChangeHook";
+import Dropdown, { DropdownOption } from "./Dropdown";
 
 export interface MobileHeaderActionProps {
   label: string;
   icon: ReactNode;
-  action: () => void;
+  action?: () => void;
+  options?: DropdownOption[];
   disabled?: boolean;
 }
 
@@ -19,13 +21,13 @@ interface MobileHeaderProps {
 function MobileHeader({ title, back, actions, toTop }: MobileHeaderProps) {
   return (
     <div
-      className="sm:hidden sticky inset-x-0 top-0 flex gap-2 justify-between items-center z-[10] bg-base-100/70 p-2 
-       -mt-2 backdrop-blur-md animate-fadeInDown animate-duration-500"
+      className="sticky inset-x-0 top-0 z-[10] -mt-2 flex animate-fadeInDown items-center justify-between gap-2 bg-base-100/70 
+       p-2 backdrop-blur-md animate-duration-500 sm:hidden"
     >
-      <div className="flex gap-1 items-center">
+      <div className="flex items-center gap-1">
         {back && (
           <button
-            className="btn rounded-xl btn-sm btn-ghost text-2xl text-primary aspect-square p-0 self-start"
+            className="btn-ghost btn-sm btn aspect-square self-start rounded-xl p-0 text-2xl text-primary"
             onClick={() => {
               back?.();
             }}
@@ -35,25 +37,27 @@ function MobileHeader({ title, back, actions, toTop }: MobileHeaderProps) {
         )}
         <span
           className={`text-xl font-bold cursor-pointer`}
-          onClick={() => toTop ? toTop():scrollToTop(true)}
+          onClick={() => (toTop ? toTop() : scrollToTop(true))}
         >
           {title}
         </span>
       </div>
       {!!actions?.length && (
-        <div className="flex gap-2 items-center">
+        <div className="flex items-center gap-2">
           {actions.map((e, idx) => {
             return (
-              <button
-                key={idx}
-                className={`btn rounded-xl btn-sm  text-2xl  aspect-square p-0
-                ${e.disabled ? "!bg-opacity-10" : "btn-ghost text-primary"}`}
-                onClick={e.disabled ? undefined : e.action}
-                title={e.label}
-                disabled={e.disabled}
-              >
-                {e.icon}
-              </button>
+              <Dropdown key={idx} options={e.options || []} className="dropdown-end">
+                <button
+                  tabIndex={0}
+                  className={`btn rounded-xl btn-sm  text-2xl  aspect-square p-0
+                  ${e.disabled ? "!bg-opacity-10" : "btn-ghost text-primary"}`}
+                  onClick={e.disabled ? undefined : e.action}
+                  title={e.label}
+                  disabled={e.disabled}
+                >
+                  {e.icon}
+                </button>
+              </Dropdown>
             );
           })}
         </div>

--- a/components/main/MobileHeader.tsx
+++ b/components/main/MobileHeader.tsx
@@ -34,7 +34,7 @@ function MobileHeader({ title, back, actions, toTop }: MobileHeaderProps) {
           </button>
         )}
         <span
-          className={`text-xl font-bold ${toTop ? `cursor-pointer` : ``}`}
+          className={`text-xl font-bold cursor-pointer`}
           onClick={() => toTop ? toTop():scrollToTop(true)}
         >
           {title}

--- a/components/modal/ModalTemplate.tsx
+++ b/components/modal/ModalTemplate.tsx
@@ -65,38 +65,47 @@ ModalProps & ModalTemplateProps) => {
             ${fullscreen ? "h-full" : "max-h-full sm:p-8"}`}
           >
             <div
-              id={`modal-content`}
               className={`modal-box !pointer-events-auto relative flex w-full flex-1 
-              !translate-y-0 !scale-[1] flex-col gap-4 ring-1 ring-base-content/20
-              p-0
+              !translate-y-0 !scale-[1] ring-1 ring-base-content/20
+              p-0 overflow-hidden
               ${
                 fullscreen
                   ? "!rounded-none !max-w-[100vw] !w-screen !max-h-screen "
-                  : "rounded-t-xl rounded-b-none sm:!rounded-xl sm:!max-w-md md:!max-w-lg lg:!max-w-xl !max-h-screen "
+                  : `rounded-t-xl rounded-b-none max-w-full sm:!rounded-xl sm:!max-w-md md:!max-w-lg lg:!max-w-xl 
+                  !max-h-[90vh]`
               }`}
             >
-              {/* gradient background */}
-              {/* <GradientBackground height="100%" /> */}
-              {noHeader || (
-                <Dialog.Title as="div" className="">
-                  <div className="flex flex-row items-center justify-between">
-                    <span className="text-xl font-bold sm:text-2xl">
-                      {title}
-                    </span>
-                    {noCloseButton || (
-                      <span
-                        className="btn btn-ghost btn-sm aspect-square !h-9 !w-9 rounded-xl 
-                        !p-0 opacity-80 hover:opacity-100 sm:btn-md sm:!h-12 sm:!w-12"
-                        title="Back"
-                        onClick={onClose}
-                      >
-                        <FaTimes className="text-2xl sm:text-3xl" />
+              <div
+                id={`modal-content`}
+                className={`flex flex-col gap-4 overflow-auto w-full`}
+              >
+                {/* gradient background */}
+                {/* <GradientBackground height="100%" /> */}
+                {noHeader || (
+                  <Dialog.Title
+                    as="div"
+                    className="hidden sm:block p-2 sm:p-4 z-[1] bg-base-100/70 backdrop-blur-md animate-fadeInDown
+                  sticky top-0 duration-500"
+                  >
+                    <div className="flex flex-row items-center justify-between">
+                      <span className="text-xl font-bold sm:text-2xl">
+                        {title}
                       </span>
-                    )}
-                  </div>
-                </Dialog.Title>
-              )}
-              {children}
+                      {noCloseButton || (
+                        <span
+                          className="btn btn-ghost btn-sm aspect-square !h-9 !w-9 rounded-xl 
+                        !p-0 opacity-80 hover:opacity-100 sm:btn-md sm:!h-12 sm:!w-12"
+                          title="Back"
+                          onClick={onClose}
+                        >
+                          <FaTimes className="text-2xl sm:text-3xl" />
+                        </span>
+                      )}
+                    </div>
+                  </Dialog.Title>
+                )}
+                {children}
+              </div>
             </div>
           </Dialog.Panel>
         </Transition.Child>

--- a/layouts/article/comment/LayoutArticleCommentForm.tsx
+++ b/layouts/article/comment/LayoutArticleCommentForm.tsx
@@ -98,4 +98,4 @@ function LayoutArticleCommentForm({
   );
 }
 
-export default LayoutArticleCommentForm;
+export default React.memo(LayoutArticleCommentForm);

--- a/layouts/article/comment/LayoutArticleCommentSection.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSection.tsx
@@ -32,7 +32,7 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
       // define where to start
       // console.log('123');
 
-      const startFrom = newSortingType || !commentList ? 0 : commentList.offset;
+      const startFrom = !!newSortingType || !commentList ? 0 : commentList.offset;
       const commentsFromDb = await fbCommentGet({
         data: {
           articleId,
@@ -58,7 +58,7 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
         // setSortedBy(sortBy || sortedBy);
       }
     },
-    [commentList?.offset],
+    [commentList],
   );
 
   const sortOptions: DropdownOption[] = useMemo(

--- a/layouts/article/comment/LayoutArticleCommentSection.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSection.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { MdSort } from "react-icons/md";
 import ArticleComments from "../../../components/article/ArticleComments";
 import Alert from "../../../components/main/Alert";
@@ -23,10 +23,13 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
 
   const loadComments = async (sortBy?: CommentModelsSortType) => {
     const commentsFromDb = await fbCommentGet({
-      data: { articleId, start: 0, count: 5, sortBy: sortedBy },
+      data: { articleId, start: 0, count: 5, sortBy: sortBy || sortedBy },
     });
-    // console.log("commentsFromDb", commentsFromDb);
-    if (commentsFromDb) setCommentList(commentsFromDb);
+    console.log("commentsFromDb", commentsFromDb);
+    if (commentsFromDb) {
+      setCommentList(commentsFromDb);
+      setSortedBy(sortBy || sortedBy);
+    }
   };
 
   const sorts: {
@@ -60,12 +63,18 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
     if (sortedBy === "top") return "top comments";
     else return "";
   }
-
+  // console.log("sortedBy", sortedBy);
+  useEffect(() => {
+    loadComments;
+    return () => {};
+  }, []);
+  
   useEffect(() => {
     loadComments();
+    return () => {};
   }, [sortedBy]);
 
-  console.log(user);
+  // console.log(user);
   // console.log("commentList", commentList);
 
   // console.log("render ArticleCommentSection");
@@ -167,14 +176,15 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
           <ArticleComments commentList={commentList} />
         )}
       </div>
-      {commentList && commentList.total > 5 && (
+      {commentList && commentList?.total > 5 && (
         <LayoutArticleCommentSectionExpandedModal
           commentList={commentList}
           articleId={articleId}
+          loadComments={loadComments}
         />
       )}
     </>
   );
 }
 
-export default LayoutArticleCommentSection;
+export default React.memo(LayoutArticleCommentSection);

--- a/layouts/article/comment/LayoutArticleCommentSection.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSection.tsx
@@ -167,7 +167,7 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
           <ArticleComments commentList={commentList} />
         )}
       </div>
-      {!!commentList?.comments.length && (
+      {commentList && commentList.total > 5 && (
         <LayoutArticleCommentSectionExpandedModal
           commentList={commentList}
           articleId={articleId}

--- a/layouts/article/comment/LayoutArticleCommentSection.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSection.tsx
@@ -1,16 +1,17 @@
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { MdSort } from "react-icons/md";
 import ArticleComments from "../../../components/article/ArticleComments";
+import Alert from "../../../components/main/Alert";
 import { useAuthCtx } from "../../../utils/contexts/auth/AuthHook";
 import {
-  CommentModelsSortType,
   CommentModelListPagedSorted,
+  CommentModelsSortType,
 } from "../../../utils/data/models/CommentModel";
+import { getElById } from "../../../utils/helpers/UiHelpers";
 import { fbCommentGet } from "../../../utils/services/network/FirebaseApi/FirebaseCommentModules";
 import LayoutArticleCommentForm from "./LayoutArticleCommentForm";
-import Link from "next/link";
-import Alert from "../../../components/main/Alert";
-import { getElById } from "../../../utils/helpers/UiHelpers";
+import LayoutArticleCommentSectionExpandedModal from "./LayoutArticleCommentSectionExpandedModal";
 
 function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
   const {
@@ -69,102 +70,110 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
 
   // console.log("render ArticleCommentSection");
   return (
-    <div className="flex flex-col gap-4 sm:gap-8">
-      {commentList?.comments.length && (
-        <div className="flex animate-fadeIn items-center justify-between gap-2 sm:justify-start sm:gap-4 z-[1]">
-          <span className="truncate text-sm font-bold sm:text-base">{`${commentList.comments.length} Comments`}</span>
-          <div className="dropdown-end dropdown">
-            <label
-              tabIndex={0}
-              className="btn-ghost btn flex-nowrap gap-2 rounded-xl sm:gap-4 "
-            >
-              <label className="text-xl sm:text-2xl">
-                <MdSort />
+    <>
+      <div className="flex flex-col gap-4 sm:gap-8">
+        {commentList?.comments.length && (
+          <div className="flex animate-fadeIn items-center justify-between gap-2 sm:justify-start sm:gap-4 z-[1]">
+            <span className="truncate text-sm font-bold sm:text-base">{`${commentList.total} Comments`}</span>
+            <div className="dropdown-end dropdown">
+              <label
+                tabIndex={0}
+                className="btn-ghost btn flex-nowrap gap-2 rounded-xl sm:gap-4 "
+              >
+                <label className="text-xl sm:text-2xl">
+                  <MdSort />
+                </label>
+                <span className="truncate text-sm sm:text-base">
+                  Sorted by{" "}
+                  <span className="underline">{getSortedByLabel()}</span>
+                </span>
               </label>
-              <span className="truncate text-sm sm:text-base">
-                Sorted by{" "}
-                <span className="underline">{getSortedByLabel()}</span>
-              </span>
-            </label>
-            <ul
-              tabIndex={0}
-              className="dropdown-content menu !z-[1] w-52 rounded-xl bg-base-300 p-2 text-sm
-              font-bold ring-[1px] ring-base-content/10 sm:text-base [&_a]:!rounded-xl"
-            >
-              {sorts.map((e, idx) => {
-                return (
-                  <li key={idx}>
-                    <a
-                      onClick={() => {
-                        e.action?.();
-                        (document.activeElement as HTMLElement).blur();
-                      }}
-                    >
-                      {e.label}
-                    </a>
-                  </li>
-                );
-              })}
-            </ul>
+              <ul
+                tabIndex={0}
+                className="dropdown-content menu !z-[1] w-52 rounded-xl bg-base-300 p-2 text-sm
+            font-bold ring-[1px] ring-base-content/10 sm:text-base [&_a]:!rounded-xl"
+              >
+                {sorts.map((e, idx) => {
+                  return (
+                    <li key={idx}>
+                      <a
+                        onClick={() => {
+                          e.action?.();
+                          (document.activeElement as HTMLElement).blur();
+                        }}
+                      >
+                        {e.label}
+                      </a>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
           </div>
-        </div>
-      )}
+        )}
 
-      {user && (
-        <LayoutArticleCommentForm
+        {user && (
+          <LayoutArticleCommentForm
+            articleId={articleId}
+            loadComments={loadComments}
+          />
+        )}
+        {!user && (
+          <div className="my-4 flex w-full animate-fadeIn flex-col rounded-xl bg-primary/10 p-4 text-center sm:my-8 sm:p-8">
+            <div className="flex w-full flex-wrap items-center justify-center gap-4 sm:gap-8">
+              <span className="flex-2 w-full text-lg font-bold  sm:text-xl">
+                Join us now, let us know what do you think about this amazing
+                article!
+              </span>
+              <Link
+                href={{
+                  pathname: "/auth",
+                }}
+                passHref
+              >
+                <a className="--btn-resp flex-2 btn-primary btn w-full gap-2 font-bold normal-case sm:flex-[2_2_0%]">
+                  Login, if have account
+                </a>
+              </Link>
+              <Link
+                href={{
+                  pathname: "/auth",
+                }}
+                passHref
+              >
+                <a className="--btn-resp flex-2 btn-primary btn w-full gap-2 font-bold normal-case sm:flex-[2_2_0%]">
+                  {`Register, if you don't`}
+                </a>
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {!commentList?.comments.length ? (
+          <Alert
+            actions={[
+              {
+                label: "Comment",
+                className: "",
+                action() {
+                  getElById("article-comment-input")?.focus();
+                },
+              },
+            ]}
+          >
+            <span>{`No comments yet, let the people know, what's your thought about this article..`}</span>
+          </Alert>
+        ) : (
+          <ArticleComments commentList={commentList} />
+        )}
+      </div>
+      {!!commentList?.comments.length && (
+        <LayoutArticleCommentSectionExpandedModal
+          commentList={commentList}
           articleId={articleId}
-          loadComments={loadComments}
         />
       )}
-      {!user && (
-        <div className="my-4 flex w-full animate-fadeIn flex-col rounded-xl bg-primary/10 p-4 text-center sm:my-8 sm:p-8">
-          <div className="flex w-full flex-wrap items-center justify-center gap-4 sm:gap-8">
-            <span className="flex-2 w-full text-lg font-bold  sm:text-xl">
-              Join us now, let us know what do you think about this amazing
-              article!
-            </span>
-            <Link
-              href={{
-                pathname: "/auth",
-              }}
-              passHref
-            >
-              <a className="--btn-resp flex-2 btn-primary btn w-full gap-2 font-bold normal-case sm:flex-[2_2_0%]">
-                Login, if have account
-              </a>
-            </Link>
-            <Link
-              href={{
-                pathname: "/auth",
-              }}
-              passHref
-            >
-              <a className="--btn-resp flex-2 btn-primary btn w-full gap-2 font-bold normal-case sm:flex-[2_2_0%]">
-                {`Register, if you don't`}
-              </a>
-            </Link>
-          </div>
-        </div>
-      )}
-
-      {!commentList?.comments.length ? (
-        <Alert
-          actions={[
-            {
-              label: "Comment",
-              className: "",
-              action() {
-                getElById("article-comment-input")?.focus();
-              },
-            },
-          ]}
-        >
-          <span>{`No comments yet, let the people know, what's your thought about this article..`}</span>
-        </Alert>
-      ) : (
-        <ArticleComments commentList={commentList} />
-      )}
-    </div>
+    </>
   );
 }
 

--- a/layouts/article/comment/LayoutArticleCommentSection.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSection.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { MdSort } from "react-icons/md";
 import ArticleComments from "../../../components/article/ArticleComments";
 import Alert from "../../../components/main/Alert";
+import Dropdown,{ DropdownOption } from "../../../components/main/Dropdown";
 import { useAuthCtx } from "../../../utils/contexts/auth/AuthHook";
 import {
   CommentModelListPagedSorted,
@@ -60,37 +61,31 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
     [commentList?.offset],
   );
 
-  const sorts: {
-    type: CommentModelsSortType | "cancel";
-    label: string;
-    action?: () => void;
-  }[] = [
-    {
-      type: "new",
-      label: "Newest first",
-      action: () => {
-        setSortedBy("new");
+  const sortOptions: DropdownOption[] = useMemo(
+    () => [
+      {
+        label: "Newest first",
+        action: () => {
+          setSortedBy("new");
+        },
       },
-    },
-    {
-      type: "top",
-      label: "Top comments",
-      action: () => {
-        setSortedBy("top");
+      {
+        label: "Top comments",
+        action: () => {
+          setSortedBy("top");
+        },
       },
-    },
-    {
-      type: "cancel",
-      label: "Cancel",
-      // action: () => {},
-    },
-  ];
+    ],
+    [],
+  );
 
   function getSortedByLabel() {
     if (sortedBy === "new") return "newest first";
     if (sortedBy === "top") return "top comments";
     else return "";
   }
+
+  // console.log(sortOptions);
   // console.log("sortedBy", sortedBy);
   useEffect(() => {
     loadComments();
@@ -112,7 +107,7 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
         {commentList?.comments.length && (
           <div className="flex animate-fadeIn items-center justify-between gap-2 sm:justify-start sm:gap-4 z-[1]">
             <span className="truncate text-sm font-bold sm:text-base">{`${commentList.total} Comments`}</span>
-            <div className="dropdown-end dropdown">
+            <Dropdown options={sortOptions}>
               <label
                 tabIndex={0}
                 className="btn-ghost btn flex-nowrap gap-2 rounded-xl sm:gap-4 "
@@ -125,34 +120,14 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
                   <span className="underline">{getSortedByLabel()}</span>
                 </span>
               </label>
-              <ul
-                tabIndex={0}
-                className="dropdown-content menu !z-[1] w-52 rounded-xl bg-base-300 p-2 text-sm
-                font-bold ring-[1px] ring-base-content/10 sm:text-base [&_a]:!rounded-xl"
-              >
-                {sorts.map((e, idx) => {
-                  return (
-                    <li key={idx}>
-                      <a
-                        onClick={() => {
-                          e.action?.();
-                          (document.activeElement as HTMLElement).blur();
-                        }}
-                      >
-                        {e.label}
-                      </a>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
+            </Dropdown>
           </div>
         )}
 
         {user && (
           <LayoutArticleCommentForm
             articleId={articleId}
-            loadComments={async ()=>{
+            loadComments={async () => {
               await loadComments("new");
             }}
           />
@@ -214,6 +189,7 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
             await waitFor(300);
             await loadComments();
           }}
+          sortOptions={sortOptions}
         />
       )}
     </>

--- a/layouts/article/comment/LayoutArticleCommentSection.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSection.tsx
@@ -29,6 +29,8 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
   const loadComments = useCallback(
     async (newSortingType?: CommentModelsSortType) => {
       // define where to start
+      // console.log('123');
+
       const startFrom = newSortingType || !commentList ? 0 : commentList.offset;
       const commentsFromDb = await fbCommentGet({
         data: {
@@ -150,7 +152,9 @@ function LayoutArticleCommentSection({ articleId }: { articleId: string }) {
         {user && (
           <LayoutArticleCommentForm
             articleId={articleId}
-            loadComments={loadComments}
+            loadComments={async ()=>{
+              await loadComments("new");
+            }}
           />
         )}
         {!user && (

--- a/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
@@ -5,13 +5,13 @@ import ArticleComments from "../../../components/article/ArticleComments";
 import { DropdownOption } from "../../../components/main/Dropdown";
 import MainIntersectionObserverTrigger from "../../../components/main/MainIntersectionObserverTrigger";
 import MobileHeader, {
-  MobileHeaderActionProps
+  MobileHeaderActionProps,
 } from "../../../components/main/MobileHeader";
 import ModalTemplate from "../../../components/modal/ModalTemplate";
 import LoadingIndicator from "../../../components/placeholder/LoadingIndicator";
 import {
   CommentModelsSortType,
-  CommentModelsWithPaging
+  CommentModelsWithPaging,
 } from "../../../utils/data/models/CommentModel";
 import { getElById } from "../../../utils/helpers/UiHelpers";
 import { useModalRoutedBehaviorHook } from "../../../utils/hooks/ModalRoutedBehaviorHook";
@@ -25,7 +25,7 @@ function LayoutArticleCommentSectionExpandedModal({
   commentList: CommentModelsWithPaging;
   articleId: string;
   loadComments: (sortBy?: CommentModelsSortType) => Promise<void>;
-  sortOptions:DropdownOption[],
+  sortOptions: DropdownOption[];
 }) {
   const { show: modalComments, toggle: setModalComments } =
     useModalRoutedBehaviorHook("comments");
@@ -35,7 +35,7 @@ function LayoutArticleCommentSectionExpandedModal({
         {
           label: "Sort",
           icon: <MdSort />,
-          options:sortOptions,
+          options: sortOptions,
         },
         {
           label: "Reload",
@@ -80,7 +80,7 @@ function LayoutArticleCommentSectionExpandedModal({
           }}
         />
         <div className="flex flex-col gap-2 p-2 sm:gap-4 sm:p-4">
-          <ArticleComments commentList={commentList} />
+          <ArticleComments commentList={commentList} observe />
           {!loading && commentList.comments.length < commentList.total && (
             <MainIntersectionObserverTrigger
               className="h-24 w-full "

--- a/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
@@ -75,7 +75,7 @@ function LayoutArticleCommentSectionExpandedModal({
           <ArticleComments commentList={commentList} />
           {!loading && commentList.comments.length < commentList.total && (
             <MainIntersectionObserverTrigger
-              className="w-full h-24 bg-red-500"
+              className="w-full h-24 "
               callback={async (intersecting) => {
                 // console.log(intersecting);
                 if (intersecting) {

--- a/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
@@ -1,16 +1,17 @@
 import { isEqual } from "lodash";
 import React, { useMemo, useState } from "react";
-import { MdExpandMore, MdRefresh } from "react-icons/md";
+import { MdExpandMore, MdRefresh, MdSort } from "react-icons/md";
 import ArticleComments from "../../../components/article/ArticleComments";
+import { DropdownOption } from "../../../components/main/Dropdown";
 import MainIntersectionObserverTrigger from "../../../components/main/MainIntersectionObserverTrigger";
 import MobileHeader, {
-  MobileHeaderActionProps,
+  MobileHeaderActionProps
 } from "../../../components/main/MobileHeader";
 import ModalTemplate from "../../../components/modal/ModalTemplate";
 import LoadingIndicator from "../../../components/placeholder/LoadingIndicator";
 import {
   CommentModelsSortType,
-  CommentModelsWithPaging,
+  CommentModelsWithPaging
 } from "../../../utils/data/models/CommentModel";
 import { getElById } from "../../../utils/helpers/UiHelpers";
 import { useModalRoutedBehaviorHook } from "../../../utils/hooks/ModalRoutedBehaviorHook";
@@ -19,16 +20,23 @@ function LayoutArticleCommentSectionExpandedModal({
   commentList,
   articleId,
   loadComments,
+  sortOptions,
 }: {
   commentList: CommentModelsWithPaging;
   articleId: string;
   loadComments: (sortBy?: CommentModelsSortType) => Promise<void>;
+  sortOptions:DropdownOption[],
 }) {
   const { show: modalComments, toggle: setModalComments } =
     useModalRoutedBehaviorHook("comments");
   const headerActions: MobileHeaderActionProps[] = useMemo(
     () =>
       [
+        {
+          label: "Sort",
+          icon: <MdSort />,
+          options:sortOptions,
+        },
         {
           label: "Reload",
           icon: <MdRefresh />,
@@ -44,7 +52,7 @@ function LayoutArticleCommentSectionExpandedModal({
     <>
       {/* trigger */}
       <button
-        className="btn btn-ghost bg-primary/30 hover:bg-primary/100 transition-all gap-2 sm:gap-4 rounded-xl mx-auto"
+        className="btn-ghost btn mx-auto gap-2 rounded-xl bg-primary/30 transition-all hover:bg-primary/100 sm:gap-4"
         onClick={() => {
           setModalComments(true, true);
         }}
@@ -71,11 +79,11 @@ function LayoutArticleCommentSectionExpandedModal({
               return modalContentEl.scrollTo({ top: 0, behavior: "smooth" });
           }}
         />
-        <div className="flex flex-col gap-2 sm:gap-4 p-2 sm:p-4">
+        <div className="flex flex-col gap-2 p-2 sm:gap-4 sm:p-4">
           <ArticleComments commentList={commentList} />
           {!loading && commentList.comments.length < commentList.total && (
             <MainIntersectionObserverTrigger
-              className="w-full h-24 "
+              className="h-24 w-full "
               callback={async (intersecting) => {
                 // console.log(intersecting);
                 if (intersecting) {

--- a/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
@@ -71,7 +71,7 @@ function LayoutArticleCommentSectionExpandedModal({
           back={() => {
             setModalComments(false);
           }}
-          title="Comments"
+          title={`Comments`}
           actions={headerActions}
           toTop={() => {
             const modalContentEl = getElById("modal-content");
@@ -79,10 +79,11 @@ function LayoutArticleCommentSectionExpandedModal({
               return modalContentEl.scrollTo({ top: 0, behavior: "smooth" });
           }}
         />
-        <div className="flex flex-col gap-2 p-2 sm:gap-4 sm:p-4">
+        <div className="flex flex-col gap-2 p-2 sm:gap-4 sm:p-4 animate-slideInUp animate-duration-300 animate-delay-[1]">
           <ArticleComments commentList={commentList} observe />
           {!loading && commentList.comments.length < commentList.total && (
             <MainIntersectionObserverTrigger
+              key={commentList.offset}
               className="h-24 w-full "
               callback={async (intersecting) => {
                 // console.log(intersecting);
@@ -112,3 +113,4 @@ export default React.memo(
     return propsAreEqual;
   },
 );
+// export default LayoutArticleCommentSectionExpandedModal;

--- a/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
@@ -1,23 +1,26 @@
-import { useMemo, useState } from "react";
+import { isEqual } from "lodash";
+import React, { useMemo } from "react";
 import { MdExpandMore, MdRefresh } from "react-icons/md";
 import ArticleComments from "../../../components/article/ArticleComments";
-import MobileHeader, {
-  MobileHeaderActionProps
-} from "../../../components/main/MobileHeader";
+import MobileHeader, { MobileHeaderActionProps } from "../../../components/main/MobileHeader";
 import ModalTemplate from "../../../components/modal/ModalTemplate";
-import { CommentModelsWithPaging } from "../../../utils/data/models/CommentModel";
+import {
+  CommentModelsSortType,
+  CommentModelsWithPaging,
+} from "../../../utils/data/models/CommentModel";
 import { getElById } from "../../../utils/helpers/UiHelpers";
 import { useModalRoutedBehaviorHook } from "../../../utils/hooks/ModalRoutedBehaviorHook";
 
 function LayoutArticleCommentSectionExpandedModal({
   commentList,
   articleId,
+  loadComments,
 }: {
   commentList: CommentModelsWithPaging;
   articleId: string;
+  loadComments: (sortBy?: CommentModelsSortType) => void;
 }) {
-  const [comments, setComments] =
-    useState<CommentModelsWithPaging>(commentList);
+  console.log("render this");
   const { show: modalComments, toggle: setModalComments } =
     useModalRoutedBehaviorHook("comments");
   const headerActions: MobileHeaderActionProps[] = useMemo(
@@ -42,7 +45,7 @@ function LayoutArticleCommentSectionExpandedModal({
           setModalComments(true, true);
         }}
       >
-        <MdExpandMore className="text-2xl sm:text-3xl"/>
+        <MdExpandMore className="text-2xl sm:text-3xl" />
         <span className="text-sm sm:text-base">Show more comments</span>
       </button>
       <ModalTemplate
@@ -65,12 +68,29 @@ function LayoutArticleCommentSectionExpandedModal({
           }}
         />
         <div className="flex flex-col gap-2 sm:gap-4 p-2 sm:p-4">
-          <ArticleComments commentList={comments} />
-          <div className="w-full h-24">loading trigger</div>
+          <ArticleComments commentList={commentList} />
+          <div
+            className="w-full h-24"
+            onClick={() => {
+              loadComments("top");
+            }}
+          >
+            loading trigger
+          </div>
         </div>
       </ModalTemplate>
     </>
   );
 }
 
-export default LayoutArticleCommentSectionExpandedModal;
+export default React.memo(
+  LayoutArticleCommentSectionExpandedModal,
+  (prev, next) => {
+    // console.log("prev", prev);
+    // console.log("next", next);
+    const propsAreEqual = isEqual(prev.commentList, next.commentList);
+    // console.log(propsAreEqual);
+
+    return propsAreEqual;
+  },
+);

--- a/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
@@ -1,8 +1,8 @@
-import React, { useMemo, useState } from "react";
-import { MdRefresh } from "react-icons/md";
+import { useMemo, useState } from "react";
+import { MdMoreHoriz, MdRefresh } from "react-icons/md";
 import ArticleComments from "../../../components/article/ArticleComments";
 import MobileHeader, {
-  MobileHeaderActionProps,
+  MobileHeaderActionProps
 } from "../../../components/main/MobileHeader";
 import ModalTemplate from "../../../components/modal/ModalTemplate";
 import { CommentModelsWithPaging } from "../../../utils/data/models/CommentModel";
@@ -35,13 +35,15 @@ function LayoutArticleCommentSectionExpandedModal({
   );
   return (
     <>
+      {/* trigger */}
       <button
-        className="btn btn-ghost sm:btn-lg"
+        className="btn btn-ghost sm:btn-lg gap-2 sm:gap-4"
         onClick={() => {
           setModalComments(true, true);
         }}
       >
-        Show more comments {commentList.comments.length}
+        <MdMoreHoriz className="text-2xl sm:text-3xl"/>
+        Show more comments
       </button>
       <ModalTemplate
         value={modalComments}

--- a/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
@@ -1,9 +1,13 @@
 import { isEqual } from "lodash";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { MdExpandMore, MdRefresh } from "react-icons/md";
 import ArticleComments from "../../../components/article/ArticleComments";
-import MobileHeader, { MobileHeaderActionProps } from "../../../components/main/MobileHeader";
+import MainIntersectionObserverTrigger from "../../../components/main/MainIntersectionObserverTrigger";
+import MobileHeader, {
+  MobileHeaderActionProps,
+} from "../../../components/main/MobileHeader";
 import ModalTemplate from "../../../components/modal/ModalTemplate";
+import LoadingIndicator from "../../../components/placeholder/LoadingIndicator";
 import {
   CommentModelsSortType,
   CommentModelsWithPaging,
@@ -18,9 +22,8 @@ function LayoutArticleCommentSectionExpandedModal({
 }: {
   commentList: CommentModelsWithPaging;
   articleId: string;
-  loadComments: (sortBy?: CommentModelsSortType) => void;
+  loadComments: (sortBy?: CommentModelsSortType) => Promise<void>;
 }) {
-  console.log("render this");
   const { show: modalComments, toggle: setModalComments } =
     useModalRoutedBehaviorHook("comments");
   const headerActions: MobileHeaderActionProps[] = useMemo(
@@ -36,6 +39,7 @@ function LayoutArticleCommentSectionExpandedModal({
       ] as MobileHeaderActionProps[],
     [],
   );
+  const [loading, setLoading] = useState(false);
   return (
     <>
       {/* trigger */}
@@ -69,14 +73,20 @@ function LayoutArticleCommentSectionExpandedModal({
         />
         <div className="flex flex-col gap-2 sm:gap-4 p-2 sm:p-4">
           <ArticleComments commentList={commentList} />
-          <div
-            className="w-full h-24"
-            onClick={() => {
-              loadComments("top");
-            }}
-          >
-            loading trigger
-          </div>
+          {!loading && commentList.comments.length < commentList.total && (
+            <MainIntersectionObserverTrigger
+              className="w-full h-24 bg-red-500"
+              callback={async (intersecting) => {
+                // console.log(intersecting);
+                if (intersecting) {
+                  setLoading(intersecting);
+                  await loadComments();
+                  setLoading(false);
+                }
+              }}
+            />
+          )}
+          {loading && <LoadingIndicator spinner />}
         </div>
       </ModalTemplate>
     </>

--- a/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { MdMoreHoriz, MdRefresh } from "react-icons/md";
+import { MdExpandMore, MdRefresh } from "react-icons/md";
 import ArticleComments from "../../../components/article/ArticleComments";
 import MobileHeader, {
   MobileHeaderActionProps
@@ -37,13 +37,13 @@ function LayoutArticleCommentSectionExpandedModal({
     <>
       {/* trigger */}
       <button
-        className="btn btn-ghost sm:btn-lg gap-2 sm:gap-4"
+        className="btn btn-ghost bg-primary/30 hover:bg-primary/100 transition-all gap-2 sm:gap-4 rounded-xl mx-auto"
         onClick={() => {
           setModalComments(true, true);
         }}
       >
-        <MdMoreHoriz className="text-2xl sm:text-3xl"/>
-        Show more comments
+        <MdExpandMore className="text-2xl sm:text-3xl"/>
+        <span className="text-sm sm:text-base">Show more comments</span>
       </button>
       <ModalTemplate
         value={modalComments}

--- a/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo, useState } from "react";
+import { MdRefresh } from "react-icons/md";
+import ArticleComments from "../../../components/article/ArticleComments";
+import MobileHeader, {
+  MobileHeaderActionProps,
+} from "../../../components/main/MobileHeader";
+import ModalTemplate from "../../../components/modal/ModalTemplate";
+import { CommentModelsWithPaging } from "../../../utils/data/models/CommentModel";
+import { getElById } from "../../../utils/helpers/UiHelpers";
+import { useModalRoutedBehaviorHook } from "../../../utils/hooks/ModalRoutedBehaviorHook";
+
+function LayoutArticleCommentSectionExpandedModal({
+  commentList,
+  articleId,
+}: {
+  commentList: CommentModelsWithPaging;
+  articleId: string;
+}) {
+  const [comments, setComments] =
+    useState<CommentModelsWithPaging>(commentList);
+  const { show: modalComments, toggle: setModalComments } =
+    useModalRoutedBehaviorHook("comments");
+  const headerActions: MobileHeaderActionProps[] = useMemo(
+    () =>
+      [
+        {
+          label: "Reload",
+          icon: <MdRefresh />,
+          action() {
+            alert("should refresh ");
+          },
+        },
+      ] as MobileHeaderActionProps[],
+    [],
+  );
+  return (
+    <>
+      <button
+        className="btn btn-ghost sm:btn-lg"
+        onClick={() => {
+          setModalComments(true, true);
+        }}
+      >
+        Show more comments {commentList.comments.length}
+      </button>
+      <ModalTemplate
+        value={modalComments}
+        onClose={() => {
+          setModalComments(false);
+        }}
+        title={`Comments`}
+      >
+        <MobileHeader
+          back={() => {
+            setModalComments(false);
+          }}
+          title="Comments"
+          actions={headerActions}
+          toTop={() => {
+            const modalContentEl = getElById("modal-content");
+            if (modalContentEl)
+              return modalContentEl.scrollTo({ top: 0, behavior: "smooth" });
+          }}
+        />
+        <div className="flex flex-col gap-2 sm:gap-4 p-2 sm:p-4">
+          <ArticleComments commentList={comments} />
+          <div className="w-full h-24">loading trigger</div>
+        </div>
+      </ModalTemplate>
+    </>
+  );
+}
+
+export default LayoutArticleCommentSectionExpandedModal;

--- a/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
+++ b/layouts/article/comment/LayoutArticleCommentSectionExpandedModal.tsx
@@ -29,13 +29,26 @@ function LayoutArticleCommentSectionExpandedModal({
 }) {
   const { show: modalComments, toggle: setModalComments } =
     useModalRoutedBehaviorHook("comments");
+  function toTop() {
+    const modalContentEl = getElById("modal-content");
+    if (modalContentEl)
+      return modalContentEl.scrollTo({ top: 0, behavior: "smooth" });
+  }
   const headerActions: MobileHeaderActionProps[] = useMemo(
     () =>
       [
         {
           label: "Sort",
           icon: <MdSort />,
-          options: sortOptions,
+          options: sortOptions.map((e) => {
+            return {
+              ...e,
+              action() {
+                e.action?.();
+                toTop();
+              },
+            };
+          }),
         },
         {
           label: "Reload",
@@ -73,11 +86,7 @@ function LayoutArticleCommentSectionExpandedModal({
           }}
           title={`Comments`}
           actions={headerActions}
-          toTop={() => {
-            const modalContentEl = getElById("modal-content");
-            if (modalContentEl)
-              return modalContentEl.scrollTo({ top: 0, behavior: "smooth" });
-          }}
+          toTop={toTop}
         />
         <div className="flex flex-col gap-2 p-2 sm:gap-4 sm:p-4 animate-slideInUp animate-duration-300 animate-delay-[1]">
           <ArticleComments commentList={commentList} observe />

--- a/utils/hooks/ModalRoutedBehaviorHook.ts
+++ b/utils/hooks/ModalRoutedBehaviorHook.ts
@@ -1,3 +1,4 @@
+import { omit } from "lodash";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 
@@ -30,11 +31,17 @@ export function useModalRoutedBehaviorHook(mainParam: string) {
 
   // close state
   const close = useCallback(() => {
-    // const currentPath = routeTrimQuery(router.asPath);
-    // router.replace(currentPath, undefined, {
-    //   shallow: true,
-    // });
-    if(value) router.back();
+    const queryAfterBacking = omit(router.query, [mainParam]);
+    router.replace(
+      {
+        query: queryAfterBacking,
+      },
+      undefined,
+      {
+        shallow: true,
+      },
+    );
+    // if(value) router.back();
   }, [value]);
 
   // Determine on what query/param on url, the state will change


### PR DESCRIPTION
- update : ui improv & fixed scrollToTop problem on modal where both toTop method (prop and main content scroll to top) get triggered
- update : ui improv. on modal template
- update : added CommentSectionExpandedModal
- update : added icon to expand comments btn trigger
- update : styling on expand comments trigger
- update : expand trigger now only shows when total comments is above 5
- fix : fixing some memoization problem on ArticleCommentSections and its children
- fix : pagination problem when switching the sorting type
- update : ui improv on comment expanded modal's observer trigger
- fix : typo on ArticleCommentItem date added
- update : adding comments now reloading the comments feed and sort it by newest
- update : ui improv mobile header title now always show pointer cursor
- update : added dropdown component
- update : added optional props `options` to MobileHeader to show dropdown
- update : applying the new Dropdown logic to the comment section
- update : added observer to comment items
- fix : applying prooper backing method on Modal routed hook, using query trimming instead of blatant router.back() method
- fix : fixed comment expanded modal's content not showing after applying intersection observer
- update : added scroll to top functionality after changing sorting type on comment expanded modal
- udpate : more ui improv on ArticleCommentItem
